### PR TITLE
Add evil-escape-case-insensitive-key-sequence option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
         - [Key sequence](#key-sequence)
         - [Delay between keys](#delay-between-keys)
         - [Unordered key sequence](#unordered-key-sequence)
+        - [Case-insensitive key sequence](#case-insensitive-key-sequence)
         - [Excluding a major mode](#excluding-a-major-mode)
         - [Enable only for a list of major modes](#enable-only-for-a-list-of-major-modes)
         - [Inhibit evil-escape](#inhibit-evil-escape)
@@ -97,6 +98,13 @@ composed with the two same characters it is recommended to set the delay to
 
 The key sequence can be entered in any order by setting
 the variable `evil-escape-unordered-key-sequence` to non nil.
+
+### Case-Insensitive key sequence
+
+The key sequence can be entered without regard to case by setting
+the variable `evil-escape-case-insensitive-key-sequence` to non nil.
+
+This allows you to use df, DF, Df or dF to escape.
 
 ### Excluding a major mode
 

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -65,6 +65,9 @@
 ;; The key sequence can be entered in any order by setting
 ;; the variable `evil-escape-unordered-key-sequence' to non nil.
 
+;; The key sequence can be made case-insensitive by setting
+;; the variable `evil-escape-case-insensitive-key-sequence' to non nil.
+
 ;; A major mode can be excluded by adding it to the list
 ;; `evil-escape-excluded-major-modes'.
 
@@ -117,6 +120,13 @@
 
 (defcustom evil-escape-unordered-key-sequence nil
   "Whether the key sequence can also be entered with the second key first."
+  :type 'boolean
+  :group 'evil-escape)
+
+(defcustom evil-escape-case-insensitive-key-sequence nil
+  "Whether the key sequence is case-insensitive.
+This makes it possible use any of \"df\", \"DF\", \"Df\" or \"dF\"
+to escape."
   :type 'boolean
   :group 'evil-escape)
 
@@ -177,6 +187,12 @@ If any of these functions return non nil, evil escape will be inhibited."
     (`multiedit-insert 'evil-multiedit-state)
     (_ (evil-escape--escape-normal-state))))
 
+(defun evil-escape-command-keys ()
+  (if (and evil-escape-case-insensitive-key-sequence
+           (char-or-string-p (this-command-keys)))
+      (downcase (this-command-keys))
+    (this-command-keys)))
+
 (defun evil-escape-pre-command-hook ()
   "evil-escape pre-command hook."
   (with-demoted-errors "evil-escape: Error %S"
@@ -193,10 +209,10 @@ If any of these functions return non nil, evil escape will be inhibited."
         (restore-buffer-modified-p modified)
         (cond
          ((and (characterp evt)
-               (or (and (equal (this-command-keys) (evil-escape--first-key))
+               (or (and (equal (evil-escape-command-keys) (evil-escape--first-key))
                         (char-equal evt skey))
                    (and evil-escape-unordered-key-sequence
-                        (equal (this-command-keys) (evil-escape--second-key))
+                        (equal (evil-escape-command-keys) (evil-escape--second-key))
                         (char-equal evt fkey))))
           (evil-repeat-stop)
           (let ((esc-fun (evil-escape-func)))
@@ -230,9 +246,9 @@ If any of these functions return non nil, evil escape will be inhibited."
        (not (memq evil-state evil-escape-excluded-states))
        (or (not evil-escape-enable-only-for-major-modes)
            (memq major-mode evil-escape-enable-only-for-major-modes))
-       (or (equal (this-command-keys) (evil-escape--first-key))
+       (or (equal (evil-escape-command-keys) (evil-escape--first-key))
            (and evil-escape-unordered-key-sequence
-                (equal (this-command-keys) (evil-escape--second-key))))
+                (equal (evil-escape-command-keys) (evil-escape--second-key))))
        (not (cl-reduce (lambda (x y) (or x y))
                        (mapcar 'funcall evil-escape-inhibit-functions)
                        :initial-value nil))))


### PR DESCRIPTION
This PR allows you to type your escape-key sequence ignoring case. So you can type "df", "Df", "dF" or "DF" and still escape, thus allowing you to escape if you're slow at releasing the shift key like I am.

This PR was originally https://github.com/syl20bnr/evil-escape/pull/88.